### PR TITLE
fix #2: free memory after demangle

### DIFF
--- a/after.js
+++ b/after.js
@@ -7,10 +7,12 @@
     if (func.length >= 2048) return null;
     m.writeStringToMemory(func.substr(1), buf);
     var ret = m['___cxa_demangle'](buf, 0, 0, status);
+    var result = null;
     if (m.HEAP32[status >> 2] === 0 && ret) {
-      return m.Pointer_stringify(ret);
+      result = m.Pointer_stringify(ret);
+      m._free(ret);
     }
-    return null;
+    return result;
   };
 })();
 

--- a/demangle.js
+++ b/demangle.js
@@ -48,10 +48,12 @@ var ra=[Sc,qc];return{_malloc:vc,_i64Subtract:Cc,_free:wc,_i64Add:Gc,_memmove:Hc
     if (func.length >= 2048) return null;
     m.writeStringToMemory(func.substr(1), buf);
     var ret = m['___cxa_demangle'](buf, 0, 0, status);
+    var result = null;
     if (m.HEAP32[status >> 2] === 0 && ret) {
-      return m.Pointer_stringify(ret);
+      result = m.Pointer_stringify(ret);
+      m._free(ret);
     }
-    return null;
+    return result;
   };
 })();
 


### PR DESCRIPTION
According to the [documentation](https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html):

> the caller is responsible for deallocating this memory using free.

Tested it on large number of functions, memory doesn't leak.
Note: this PR contains binary update, but only readable part has been changed, so I pushed it as well, as the diff is readable.
